### PR TITLE
Add env var baseurl for Mailjet Sender

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,12 @@ Open your application and send an email.
 
 You may then open http://localhost:3000 to see if the email is being dropped.
 
-### Preparing an email blacklist
+### Prepare an email blacklist
 
 SMTP Firewall reads from `bad_domains.txt` for the email blacklist.
 Each line in the file represents a domain name.
 
-You may start from downloading Email blacklist online:
+You may start from downloading email blacklist online:
 - https://github.com/disposable-email-domains/disposable-email-domains
 
 ### Select an email service proviers
@@ -74,6 +74,7 @@ Environment variables:
 |Variable|Value(example)|
 |---|---|
 |SENDER_TYPE|mailjet|
+|SENDER_MAILJET_BASEURL|(Leave it blank to apply the default base URL defined by official library)|
 |SENDER_MAILJET_APIKEY_PUBLIC|APIKEY_PUBLIC|
 |SENDER_MAILJET_APIKEY_PRIVATE|APIKEY_PRIVATE|
 

--- a/cmd/smtpfirewall/example.yaml
+++ b/cmd/smtpfirewall/example.yaml
@@ -6,6 +6,7 @@ sender:
   awsses:
     timeout: 5
   mailjet:
+    baseurl:
     apikey_public:
     apikey_private:
   smtp:

--- a/cmd/smtpfirewall/main.go
+++ b/cmd/smtpfirewall/main.go
@@ -104,10 +104,11 @@ func newSender(config *viper.Viper) (output sender.Sender) {
 		output = sender.NewAWSSESSender(int16(config.GetInt(("sender.awsses.timeout"))))
 
 	case "mailjet":
+		baseurl := config.GetString("sender.mailjet.baseurl")
 		keyPub := config.GetString("sender.mailjet.apikey_public")
 		keyPri := config.GetString("sender.mailjet.apikey_private")
 
-		output = sender.NewMailjetSender(keyPub, keyPri)
+		output = sender.NewMailjetSender(keyPub, keyPri, baseurl)
 
 	case "smtp":
 		output = sender.NewSMTPSender(config.GetString("sender.smtp.addr"), nil)

--- a/sender/mailjet_sender.go
+++ b/sender/mailjet_sender.go
@@ -14,9 +14,17 @@ type MailjetSender struct {
 	client *mailjet.Client
 }
 
-func NewMailjetSender(mjApikeyPublic string, mjApikeyPrivate string) *MailjetSender {
+func NewMailjetSender(mjApikeyPublic string, mjApikeyPrivate string, baseURL string) *MailjetSender {
+	var client *mailjet.Client
+
+	if baseURL != "" {
+		client = mailjet.NewMailjetClient(mjApikeyPublic, mjApikeyPrivate, baseURL)
+	} else {
+		client = mailjet.NewMailjetClient(mjApikeyPublic, mjApikeyPrivate)
+	}
+
 	return &MailjetSender{
-		client: mailjet.NewMailjetClient(mjApikeyPublic, mjApikeyPrivate),
+		client: client,
 	}
 }
 


### PR DESCRIPTION
To workaround the missing IPv6 support of Mailjet API.